### PR TITLE
Convert the real-time exporter from a SpanProcessor to a Tracer

### DIFF
--- a/bin/main.rs
+++ b/bin/main.rs
@@ -1,4 +1,4 @@
-use opentelemetry::trace::{TraceContextExt, Link, SpanContext};
+use opentelemetry::trace::{Link, SpanContext, TraceContextExt};
 use opentelemetry::Key;
 use opentelemetry_api::global::shutdown_tracer_provider;
 use opentelemetry_api::trace::{Span, Tracer};
@@ -10,42 +10,42 @@ const SAMPLE_KEY_INT: Key = Key::from_static_str("int");
 const SAMPLE_KEY_FLOAT: Key = Key::from_static_str("float");
 
 fn main() {
-    let tracer = otel_etw::span_exporter::new_etw_exporter("Sample-Provider-Name")
-        .with_json_payload()
-        .install_simple();
+    // let tracer = otel_etw::span_exporter::new_etw_exporter("Sample-Provider-Name")
+    //     .with_json_payload()
+    //     .install_simple();
 
     let mut span_context: SpanContext = SpanContext::empty_context();
 
-    tracer.in_span("OuterSpanName", |cx| {
-        std::thread::sleep(std::time::Duration::from_millis(1000));
+    // tracer.in_span("OuterSpanName", |cx| {
+    //     std::thread::sleep(std::time::Duration::from_millis(1000));
 
-        let span = cx.span();
+    //     let span = cx.span();
 
-        span_context = span.span_context().clone();
+    //     span_context = span.span_context().clone();
 
-        span.add_event(
-            "SampleEventName",
-            vec![
-                SAMPLE_KEY_STR.string("sample string"),
-                SAMPLE_KEY_BOOL.bool(true),
-            ],
-        );
+    //     span.add_event(
+    //         "SampleEventName",
+    //         vec![
+    //             SAMPLE_KEY_STR.string("sample string"),
+    //             SAMPLE_KEY_BOOL.bool(true),
+    //         ],
+    //     );
 
-        let span_builder = tracer
-            .span_builder("OuterSpanName")
-            .with_kind(opentelemetry::trace::SpanKind::Client)
-            .with_status(opentelemetry::trace::Status::Error {
-                description: "My error message".into(),
-            });
+    //     let span_builder = tracer
+    //         .span_builder("OuterSpanName")
+    //         .with_kind(opentelemetry::trace::SpanKind::Client)
+    //         .with_status(opentelemetry::trace::Status::Error {
+    //             description: "My error message".into(),
+    //         });
 
-        let mut span = tracer.build(span_builder);
+    //     let mut span = tracer.build(span_builder);
 
-        std::thread::sleep(std::time::Duration::from_millis(1000));
-        span.add_event("SampleEvent2", vec![]);
-        std::thread::sleep(std::time::Duration::from_millis(1000));
-    });
+    //     std::thread::sleep(std::time::Duration::from_millis(1000));
+    //     span.add_event("SampleEvent2", vec![]);
+    //     std::thread::sleep(std::time::Duration::from_millis(1000));
+    // });
 
-    std::thread::sleep(std::time::Duration::from_millis(1000));
+    // std::thread::sleep(std::time::Duration::from_millis(1000));
 
     let tracer2 =
         otel_etw::span_exporter::new_etw_exporter("Sample-Provider-Name").install_realtime();

--- a/lib/src/batch_exporter.rs
+++ b/lib/src/batch_exporter.rs
@@ -56,8 +56,8 @@ impl Debug for BatchExporter {
 }
 
 impl EtwExporter for ExporterConfig {
-    fn get_provider(&mut self) -> Pin<&mut Provider> {
-        self.provider.as_mut()
+    fn get_provider(&self) -> Pin<&Provider> {
+        self.provider.as_ref()
     }
 
     fn get_span_keywords(&self) -> u64 {

--- a/lib/src/etw_exporter.rs
+++ b/lib/src/etw_exporter.rs
@@ -552,16 +552,6 @@ impl EventBuilderWrapper {
                 &span_data.span_context.trace_id(),
             );
 
-            // self.write_events(
-            //     &tlg_provider,
-            //     Level::Verbose,
-            //     event_keywords,
-            //     &activities,
-            //     &mut span_data.events.iter(),
-            //     use_byte_for_bools,
-            //     export_payload_as_json,
-            // )?;
-
             self.write_span_event(
                 &tlg_provider,
                 &span_data.name,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -49,7 +49,7 @@
 //! Batching or asynchronous logging is not implemented by the exporter.
 //!
 //! # Span Links
-//! 
+//!
 //! Each span link is exported as a separate ETW event. The ETW event's name will
 //! match the span start event's name, and the link event's activity ID will match
 //! the span's activity ID. A `Link` field in the payload contains the linked

--- a/lib/src/realtime_exporter.rs
+++ b/lib/src/realtime_exporter.rs
@@ -1,8 +1,20 @@
 use crate::constants::*;
 use crate::etw_exporter::*;
-use opentelemetry::{trace::TraceResult, Context};
-use opentelemetry_sdk::{export::trace::SpanData, trace::SpanProcessor};
-use std::{fmt::Debug, pin::Pin, sync::Mutex};
+use opentelemetry::trace::TraceContextExt;
+use opentelemetry::trace::{
+    Event, SpanBuilder, SpanContext, SpanId, SpanKind, TraceFlags, TraceState,
+};
+use opentelemetry::Context;
+use opentelemetry_api::trace::SpanRef;
+use opentelemetry_sdk::{
+    export::trace::SpanData,
+    trace::{EvictedHashMap, EvictedQueue},
+};
+use std::borrow::Cow;
+use std::pin::Pin;
+use std::sync::Mutex;
+use std::sync::{Arc, Weak};
+use std::time::SystemTime;
 use tracelogging_dynamic::*;
 
 struct ExporterConfig {
@@ -12,54 +24,12 @@ struct ExporterConfig {
     links_keywords: u64,
     bool_intype: InType,
     json: bool,
-}
-
-pub struct RealtimeExporter {
-    // Must be boxed because SpanProcessor doesn't use mutable self,
-    // but EtwExporter and EventBuilder must be mutable.
-    config: Mutex<ExporterConfig>,
-    ebw: Mutex<EventBuilderWrapper>,
-}
-
-impl RealtimeExporter {
-    pub(crate) fn new(
-        provider_name: &str,
-        use_byte_for_bools: bool,
-        export_payload_as_json: bool,
-    ) -> Self {
-        let mut provider = Box::pin(Provider::new());
-        unsafe {
-            provider
-                .as_mut()
-                .register(provider_name, Provider::options().group_id(&GROUP_ID));
-        }
-        RealtimeExporter {
-            config: Mutex::new(ExporterConfig {
-                provider,
-                span_keywords: 1,
-                event_keywords: 2,
-                links_keywords: 4,
-                bool_intype: if use_byte_for_bools {
-                    InType::U8
-                } else {
-                    InType::Bool32
-                },
-                json: export_payload_as_json,
-            }),
-            ebw: Mutex::new(EventBuilderWrapper::new()),
-        }
-    }
-}
-
-impl Debug for RealtimeExporter {
-    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        todo!()
-    }
+    config: opentelemetry_sdk::trace::Config,
 }
 
 impl EtwExporter for ExporterConfig {
-    fn get_provider(&mut self) -> Pin<&mut Provider> {
-        self.provider.as_mut()
+    fn get_provider(&self) -> Pin<&Provider> {
+        self.provider.as_ref()
     }
 
     fn get_span_keywords(&self) -> u64 {
@@ -83,32 +53,323 @@ impl EtwExporter for ExporterConfig {
     }
 }
 
-impl SpanProcessor for RealtimeExporter {
-    fn on_start(&self, span: &mut opentelemetry_sdk::trace::Span, _cx: &Context) {
-        let mut config = self.config.lock().unwrap();
-        let _ = self.ebw.lock().unwrap().log_span_start(&mut *config, span);
+pub struct RealtimeSpan {
+    ebw: Mutex<EventBuilderWrapper>,
+    etw_config: Weak<ExporterConfig>,
+    span_data: SpanData,
+}
+
+impl RealtimeSpan {
+    fn build(
+        builder: SpanBuilder,
+        etw_config: Weak<ExporterConfig>,
+        parent_span: Option<SpanRef>,
+    ) -> Self {
+        let parent_span_id =
+            parent_span.map_or_else(|| SpanId::INVALID, |s| s.span_context().span_id());
+        let strong = etw_config.upgrade();
+        let otel_config = if let Some(config) = &strong {
+            &config.as_ref().config
+        } else {
+            panic!()
+        };
+
+        RealtimeSpan {
+            ebw: Mutex::new(EventBuilderWrapper::new()),
+            etw_config,
+            span_data: SpanData {
+                span_context: SpanContext::new(
+                    builder
+                        .trace_id
+                        .unwrap_or(otel_config.id_generator.new_trace_id()),
+                    builder
+                        .span_id
+                        .unwrap_or(otel_config.id_generator.new_span_id()),
+                    TraceFlags::SAMPLED,
+                    false,
+                    TraceState::default(),
+                ),
+                parent_span_id,
+                span_kind: builder.span_kind.unwrap_or(SpanKind::Internal),
+                name: builder.name,
+                start_time: builder.start_time.unwrap_or(SystemTime::UNIX_EPOCH),
+                end_time: builder.end_time.unwrap_or(SystemTime::UNIX_EPOCH),
+                attributes: EvictedHashMap::new(otel_config.span_limits.max_attributes_per_span, 5), // TODO - insert data
+                events: EvictedQueue::new(otel_config.span_limits.max_events_per_span),
+                links: EvictedQueue::new(otel_config.span_limits.max_links_per_span),
+                status: builder.status,
+                resource: Cow::default(),                // TODO
+                instrumentation_lib: Default::default(), // TODO
+            },
+        }
     }
 
-    fn on_end(&self, span: SpanData) {
-        let mut config = self.config.lock().unwrap();
-        let _ = self.ebw.lock().unwrap().log_span_end(&mut *config, &span);
-    }
+    fn start(&mut self) {
+        self.span_data.start_time = SystemTime::now();
+        self.span_data.end_time = self.span_data.start_time; // The spec requires this, even though it doesn't make sense.
 
-    fn force_flush(&self) -> TraceResult<()> {
-        Ok(())
-    }
-
-    fn shutdown(&mut self) -> TraceResult<()> {
-        Ok(())
+        let mut strong = self.etw_config.upgrade();
+        if let Some(prov) = strong.as_mut() {
+            if let Ok(mut ebw) = self.ebw.lock() {
+                let _ = ebw.log_span_start(prov.as_ref(), self);
+            }
+        }
     }
 }
 
-#[allow(unused_imports)]
-mod tests {
-    use super::*;
+impl opentelemetry_api::trace::Span for RealtimeSpan {
+    fn add_event<T>(&mut self, name: T, attributes: Vec<opentelemetry::KeyValue>)
+    where
+        T: Into<std::borrow::Cow<'static, str>>,
+    {
+        self.add_event_with_timestamp(name, SystemTime::now(), attributes)
+    }
 
-    #[test]
-    fn create_realtime_exporter() {
-        let _ = RealtimeExporter::new("my_provider_name", false, false);
+    fn add_event_with_timestamp<T>(
+        &mut self,
+        name: T,
+        timestamp: std::time::SystemTime,
+        attributes: Vec<opentelemetry::KeyValue>,
+    ) where
+        T: Into<std::borrow::Cow<'static, str>>,
+    {
+        let event = Event::new(name, timestamp, attributes, 0);
+
+        let mut strong = self.etw_config.upgrade();
+        if let Some(prov) = strong.as_mut() {
+            if let Ok(mut ebw) = self.ebw.lock() {
+                let _ = ebw.log_span_event(prov.as_ref(), event, self);
+            }
+        }
+    }
+
+    fn end(&mut self) {
+        let mut strong = self.etw_config.upgrade();
+        if let Some(config) = strong.as_mut() {
+            if let Ok(mut ebw) = self.ebw.lock() {
+                let _ = ebw.log_span_end(config.as_ref(), self);
+            }
+        }
+    }
+
+    fn end_with_timestamp(&mut self, timestamp: std::time::SystemTime) {
+        self.span_data.end_time = timestamp;
+        self.end()
+    }
+
+    fn is_recording(&self) -> bool {
+        let strong = self.etw_config.upgrade();
+        if let Some(config) = strong {
+            config
+                .provider
+                .enabled(Level::Informational, config.span_keywords)
+        } else {
+            false
+        }
+    }
+
+    fn record_error(&mut self, _err: &dyn std::error::Error) {
+        todo!()
+    }
+
+    fn set_attribute(&mut self, attribute: opentelemetry::KeyValue) {
+        self.span_data.attributes.insert(attribute);
+    }
+
+    fn set_attributes(&mut self, attributes: impl IntoIterator<Item = opentelemetry::KeyValue>) {
+        for attribute in attributes {
+            self.span_data.attributes.insert(attribute);
+        }
+    }
+
+    fn set_status(&mut self, status: opentelemetry::trace::Status) {
+        self.span_data.status = status;
+    }
+
+    fn span_context(&self) -> &opentelemetry::trace::SpanContext {
+        &self.span_data.span_context
+    }
+
+    fn update_name<T>(&mut self, new_name: T)
+    where
+        T: Into<std::borrow::Cow<'static, str>>,
+    {
+        self.span_data.name = new_name.into();
     }
 }
+
+impl EtwSpan for RealtimeSpan {
+    fn get_span_data(&self) -> &SpanData {
+        &self.span_data
+    }
+}
+
+pub struct RealtimeTracer {
+    etw_config: Weak<ExporterConfig>,
+}
+
+impl RealtimeTracer {
+    fn new(
+        etw_config: Weak<ExporterConfig>,
+        lib: opentelemetry_api::InstrumentationLibrary,
+    ) -> Self {
+        RealtimeTracer {
+            etw_config: etw_config,
+        }
+    }
+}
+
+impl opentelemetry_api::trace::Tracer for RealtimeTracer {
+    type Span = RealtimeSpan;
+
+    fn build_with_context(&self, builder: SpanBuilder, parent_cx: &Context) -> Self::Span {
+        let parent_span = if parent_cx.has_active_span() {
+            Some(parent_cx.span())
+        } else {
+            None
+        };
+
+        let mut span = RealtimeSpan::build(builder, self.etw_config.clone(), parent_span);
+        span.start();
+        span
+    }
+}
+
+pub struct RealtimeTracerProvider {
+    etw_config: Arc<ExporterConfig>,
+}
+
+impl RealtimeTracerProvider {
+    pub(crate) fn new(
+        provider_name: &str,
+        config: opentelemetry_sdk::trace::Config,
+        use_byte_for_bools: bool,
+        export_payload_as_json: bool,
+    ) -> Self {
+        let mut provider = Box::pin(Provider::new());
+        unsafe {
+            provider
+                .as_mut()
+                .register(provider_name, Provider::options().group_id(&GROUP_ID));
+        }
+
+        let etw_config = Arc::new(ExporterConfig {
+            provider,
+            span_keywords: 1,
+            event_keywords: 2,
+            links_keywords: 4,
+            bool_intype: if use_byte_for_bools {
+                InType::U8
+            } else {
+                InType::Bool32
+            },
+            json: export_payload_as_json,
+            config: config,
+        });
+
+        RealtimeTracerProvider { etw_config }
+    }
+}
+
+impl opentelemetry_api::trace::TracerProvider for RealtimeTracerProvider {
+    type Tracer = RealtimeTracer;
+
+    fn tracer(&self, name: impl Into<std::borrow::Cow<'static, str>>) -> Self::Tracer {
+        self.versioned_tracer(name, Some("1.0"), Some("https://microsoft.com/etw"))
+    }
+
+    fn versioned_tracer(
+        &self,
+        name: impl Into<std::borrow::Cow<'static, str>>,
+        version: Option<&'static str>,
+        schema_url: Option<&'static str>,
+    ) -> Self::Tracer {
+        let name = name.into();
+        // Use default value if name is invalid empty string
+        let component_name = if name.is_empty() {
+            Cow::Borrowed("DEFAULT_COMPONENT_NAME") // TODO
+        } else {
+            name
+        };
+        let instrumentation_lib = opentelemetry_api::InstrumentationLibrary::new(
+            component_name,
+            version.map(Into::into),
+            schema_url.map(Into::into),
+        );
+
+        RealtimeTracer::new(Arc::downgrade(&self.etw_config), instrumentation_lib)
+    }
+}
+
+// pub struct RealtimeExporter {
+//     // Must be boxed because SpanProcessor doesn't use mutable self,
+//     // but EtwExporter and EventBuilder must be mutable.
+//     config: Mutex<ExporterConfig>,
+//     ebw: Mutex<EventBuilderWrapper>,
+// }
+
+// impl RealtimeExporter {
+//     pub(crate) fn new(
+//         provider_name: &str,
+//         use_byte_for_bools: bool,
+//         export_payload_as_json: bool,
+//     ) -> Self {
+//         let mut provider = Box::pin(Provider::new());
+//         unsafe {
+//             provider
+//                 .as_mut()
+//                 .register(provider_name, Provider::options().group_id(&GROUP_ID));
+//         }
+//         RealtimeExporter {
+//             config: Mutex::new(ExporterConfig {
+//                 provider,
+//                 span_keywords: 1,
+//                 event_keywords: 2,
+//                 links_keywords: 4,
+//                 bool_intype: if use_byte_for_bools {
+//                     InType::U8
+//                 } else {
+//                     InType::Bool32
+//                 },
+//                 json: export_payload_as_json,
+//             }),
+//             ebw: Mutex::new(EventBuilderWrapper::new()),
+//         }
+//     }
+// }
+
+// impl Debug for RealtimeExporter {
+//     fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//         todo!()
+//     }
+// }
+
+// impl SpanProcessor for RealtimeExporter {
+//     fn on_start(&self, span: &mut opentelemetry_sdk::trace::Span, _cx: &Context) {
+//         let mut config = self.config.lock().unwrap();
+//         let _ = self.ebw.lock().unwrap().log_span_start(&mut *config, span);
+//     }
+
+//     fn on_end(&self, span: SpanData) {
+//         let mut config = self.config.lock().unwrap();
+//         let _ = self.ebw.lock().unwrap().log_span_end(&mut *config, &span);
+//     }
+
+//     fn force_flush(&self) -> TraceResult<()> {
+//         Ok(())
+//     }
+
+//     fn shutdown(&mut self) -> TraceResult<()> {
+//         Ok(())
+//     }
+// }
+
+// #[allow(unused_imports)]
+// mod tests {
+//     use super::*;
+
+//     #[test]
+//     fn create_realtime_exporter() {
+//         let _ = RealtimeExporter::new("my_provider_name", false, false);
+//     }
+// }


### PR DESCRIPTION
This allows for real-time logging when an event is added to a span, as well as more control over what data is available at span start (don't have to call span.export_data() and hope things are filled in).